### PR TITLE
fix: Fix shell quoting and POSIX compatibility in script.sh

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -21,7 +21,7 @@ go version -m "$(which staticcheck)"
 echo '::endgroup::'
 
 echo '::group:: Running staticcheck with reviewdog 🐶 ...'
-staticcheck "${INPUT_STATICCHECK_FLAGS}" -f=json "${INPUT_TARGET:-.}" \
+staticcheck ${INPUT_STATICCHECK_FLAGS:+"${INPUT_STATICCHECK_FLAGS}"} -f=json "${INPUT_TARGET:-.}" \
   | jq -f "${GITHUB_ACTION_PATH}/to-rdjsonl.jq" -c | \
    reviewdog \
       -f="rdjsonl" \
@@ -31,7 +31,7 @@ staticcheck "${INPUT_STATICCHECK_FLAGS}" -f=json "${INPUT_TARGET:-.}" \
       -fail-level="${INPUT_FAIL_LEVEL}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
-      "${INPUT_REVIEWDOG_FLAGS}"
+      ${INPUT_REVIEWDOG_FLAGS:+"${INPUT_REVIEWDOG_FLAGS}"}
 
 exit_code=$?
 echo '::endgroup::'


### PR DESCRIPTION
This PR fixes script to handle empty variables without passing empty string arguments.